### PR TITLE
Fix event resubscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-canvas",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "description": "High performance <canvas> rendering for React components",
   "main": "dist/index.js",
   "repository": {

--- a/src/CanvasComponent.js
+++ b/src/CanvasComponent.js
@@ -18,12 +18,16 @@ export default class CanvasComponent {
     const subscriptions = this.subscriptions;
     const listeners = this.listeners;
 
+    let isListenerDifferent = false;
     if (listeners.get(type) !== listener) {
       listeners.set(type, listener);
+      isListenerDifferent = true;
     }
 
     if (listener) {
-      if (!subscriptions.has(type)) {
+      // Add subscription if this is the first listener of the given type
+      // or the new listener is different from the current listener.
+      if (!subscriptions.has(type) || isListenerDifferent) {
         subscriptions.set(type, this.node.subscribe(type, listener, this));
       }
     } else {


### PR DESCRIPTION
An existing event handler was never replaced with a new so the first event handler for the given event handler type would be used forever.